### PR TITLE
add apply_date timestamp field to application

### DIFF
--- a/src/main/java/com/bootcamp/interviewflow/dto/ApplicationListDTO.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/ApplicationListDTO.java
@@ -19,6 +19,11 @@ public record ApplicationListDTO(
         @Schema(description = "Position applied for", example = "Backend Engineer")
         String position,
 
+        @Schema(description = "Timestamp when you actually applied for the job (optional - defaults to creation time)",
+                example = "2025-07-16T10:30:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime applyDate,
+
         @Schema(description = "Timestamp when the application was created", example = "2025-07-17 10:30:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,

--- a/src/main/java/com/bootcamp/interviewflow/dto/ApplicationResponse.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/ApplicationResponse.java
@@ -27,6 +27,11 @@ public record ApplicationResponse(
         @Schema(description = "Position or title applied for", example = "Backend Engineer")
         String position,
 
+        @Schema(description = "Timestamp when you actually applied for the job (optional - defaults to creation time)",
+                example = "2025-07-16T10:30:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime applyDate,
+
         @Schema(description = "Timestamp when the application was created", example = "2025-07-18 14:30:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,

--- a/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
@@ -1,5 +1,6 @@
 package com.bootcamp.interviewflow.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,6 +8,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Setter
 @Getter
@@ -26,6 +29,11 @@ public class CreateApplicationRequest {
     @Size(max = 100, message = "Position must not exceed 100 characters")
     @Schema(description = "Job title or position applied for", example = "Software Engineer", requiredMode = Schema.RequiredMode.REQUIRED)
     private String position;
+
+    @Schema(description = "Timestamp when you actually applied for the job (optional - defaults to creation time)",
+            example = "2025-07-16T10:30:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime applyDate;
 
     @NotBlank(message = "Status is required")
     @Pattern(

--- a/src/main/java/com/bootcamp/interviewflow/dto/UpdateApplicationRequest.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/UpdateApplicationRequest.java
@@ -3,10 +3,13 @@ package com.bootcamp.interviewflow.dto;
 import com.bootcamp.interviewflow.model.ApplicationStatus;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 public class UpdateApplicationRequest {
     private String companyName;
     private String companyLink;
     private String position;
     private ApplicationStatus status;
+    private LocalDateTime applyDate;
 }

--- a/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationListMapper.java
+++ b/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationListMapper.java
@@ -16,6 +16,7 @@ public class ApplicationListMapper {
                 application.getCompanyName(),
                 application.getCompanyLink(),
                 application.getPosition(),
+                application.getApplyDate(),
                 application.getCreatedAt(),
                 application.getUpdatedAt()
         );

--- a/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationMapper.java
+++ b/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationMapper.java
@@ -21,6 +21,9 @@ public class ApplicationMapper {
         if (dto.getPosition() != null) {
             app.setPosition(dto.getPosition());
         }
+        if (dto.getApplyDate() != null) {
+            app.setApplyDate(dto.getApplyDate());
+        }
         return app;
     }
 
@@ -31,6 +34,7 @@ public class ApplicationMapper {
                 app.getCompanyName(),
                 app.getCompanyLink(),
                 app.getPosition(),
+                app.getApplyDate(),
                 app.getCreatedAt(),
                 app.getUpdatedAt()
         );

--- a/src/main/java/com/bootcamp/interviewflow/model/Application.java
+++ b/src/main/java/com/bootcamp/interviewflow/model/Application.java
@@ -43,6 +43,9 @@ public class Application {
     @Column(length = 255)
     private String position;
 
+    @Column(name = "apply_date", nullable = false)
+    private LocalDateTime applyDate;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -55,11 +58,12 @@ public class Application {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public Application(ApplicationStatus status, String companyName, String companyLink, String position, User user) {
+    public Application(ApplicationStatus status, String companyName, String companyLink, String position, LocalDateTime applyDate, User user) {
         this.status = status;
         this.companyName = companyName;
         this.companyLink = companyLink;
         this.position = position;
+        this.applyDate = applyDate;
         this.user = user;
     }
 }

--- a/src/main/java/com/bootcamp/interviewflow/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/bootcamp/interviewflow/service/ApplicationServiceImpl.java
@@ -40,6 +40,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         app.setCompanyName(dto.getCompanyName());
         app.setCompanyLink(dto.getCompanyLink());
         app.setPosition(dto.getPosition());
+        app.setApplyDate(dto.getApplyDate());
         app.setStatus(ApplicationStatus.valueOf(dto.getStatus()));
         app.setUser(user);
 

--- a/src/main/resources/db/changelog/migrations/005-insert-test-applications.yml
+++ b/src/main/resources/db/changelog/migrations/005-insert-test-applications.yml
@@ -8,7 +8,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, valueNumeric: 1 }
               - column: { name: user_id, valueNumeric: 1 }
-              - column: { name: status, value: PENDING }
+              - column: { name: status, value: APPLIED }
               - column: { name: company_name, value: Acme Corp }
               - column: { name: company_link, value: https://acme.example.com }
               - column: { name: position, value: Backend Developer }

--- a/src/main/resources/db/changelog/migrations/007-add-apply-date-column.xml
+++ b/src/main/resources/db/changelog/migrations/007-add-apply-date-column.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.liquibase.org/xml/ns/dbchangelog
+           http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd"
+        logicalFilePath="migrations/003-add-applied-at-column.xml">
+
+    <changeSet id="007-add-apply-date-column" author="karolig">
+        <addColumn tableName="applications">
+            <column name="apply_date" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="applications" columnName="apply_date"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/com/bootcamp/interviewflow/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/controller/ApplicationControllerTest.java
@@ -37,7 +37,7 @@ class ApplicationControllerTest {
         Long userId = 42L;
         LocalDateTime now = LocalDateTime.of(2025, 7, 16, 12, 0);
         var dto = new ApplicationListDTO(
-                1L, ApplicationStatus.APPLIED, "Acme", "https://acme", "Eng", now, now
+                1L, ApplicationStatus.APPLIED, "Acme", "https://acme", "Eng",now, now, now
         );
         when(service.findAllByUserId(userId)).thenReturn(List.of(dto));
 

--- a/src/test/java/com/bootcamp/interviewflow/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/service/ApplicationServiceImplTest.java
@@ -84,8 +84,8 @@ class ApplicationServiceImplTest {
         applications = List.of(app1, app2);
 
         dtos = List.of(
-                new ApplicationListDTO(1L, APPLIED, "Acme Corp", "https://acme.example", "Software Engineer", now, now),
-                new ApplicationListDTO(2L, REJECTED, "Globex", "https://globex.example", "Business Analyst", now, now)
+                new ApplicationListDTO(1L, APPLIED, "Acme Corp", "https://acme.example", "Software Engineer", now,now, now),
+                new ApplicationListDTO(2L, REJECTED, "Globex", "https://globex.example", "Business Analyst", now,now, now)
         );
     }
 
@@ -140,6 +140,7 @@ class ApplicationServiceImplTest {
                 testApp.getCompanyName(),
                 testApp.getCompanyLink(),
                 testApp.getPosition(),
+                testApp.getApplyDate(),
                 testApp.getCreatedAt(),
                 testApp.getUpdatedAt());
 
@@ -230,6 +231,7 @@ class ApplicationServiceImplTest {
                 "oldlink.com",
                 "Old Position",
                 null,
+                null,
                 null
         );
 
@@ -279,6 +281,7 @@ class ApplicationServiceImplTest {
                 "New",
                 "old.com",
                 "NewPosition",
+                null,
                 null,
                 null
         );
@@ -341,6 +344,7 @@ class ApplicationServiceImplTest {
                 "OldName",
                 "oldlink.com",
                 "OldPosition",
+                null,
                 null,
                 null
         );

--- a/src/test/java/com/bootcamp/interviewflow/service/NotesServiceTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/service/NotesServiceTest.java
@@ -55,7 +55,9 @@ class NotesServiceTest {
                 "TestPosition",
                 now,
                 now,
+                now,
                 new User());
+
         Note note = new Note(1L, "Test note", application, now, now);
         Note testNote = new Note(application, "Test note");
 
@@ -101,6 +103,7 @@ class NotesServiceTest {
                 "TestPosition",
                 now,
                 now,
+                now,
                 new User());
         Note note = new Note(100L, "Test note", application, now, now);
 
@@ -141,6 +144,7 @@ class NotesServiceTest {
                 "TestCompany",
                 "Link",
                 "TestPosition",
+                now,
                 now,
                 now,
                 new User());


### PR DESCRIPTION
Add `applied_at` timestamp field to applications to track when users actually applied for jobs.

## Description
Users can now specify when they applied for a job, separate from when they created the application record. If no date is provided, it defaults to the creation timestamp.

##  Changes Made
- **Database**: Added `apply_date` column with NOT NULL constraint and default CURRENT_TIMESTAMP
- **Entity**: Updated `Application` entity with `applyDate` field
- **DTOs**: Added `applyDate` to request/response DTOs with proper validation
- **Mappers**: update application dto mappers to also map `applyDate` field.
- **Tests**: Updated unit tests for new field validation and mapping
- Updated Swagger documentation

**Response Example:**
```json
  {
        "id": 2,
        "status": "REJECTED",
        "companyName": "Globex Inc.",
        "companyLink": "https://globex.example.com",
        "position": "Frontend Developer",
        "applyDate": "2025-07-18 18:56:08", // defaults to creation time
        "createdAt": "2025-07-18 18:56:08",
        "updatedAt": "2025-07-18 18:56:08"
    },