### PR TITLE
Feature/if-62-enforce-per-user-authentication-for-applications-api

### DIFF
--- a/src/main/java/com/bootcamp/interviewflow/controller/ApplicationController.java
+++ b/src/main/java/com/bootcamp/interviewflow/controller/ApplicationController.java
@@ -4,6 +4,7 @@ import com.bootcamp.interviewflow.dto.ApplicationListDTO;
 import com.bootcamp.interviewflow.dto.ApplicationResponse;
 import com.bootcamp.interviewflow.dto.CreateApplicationRequest;
 import com.bootcamp.interviewflow.dto.UpdateApplicationRequest;
+import com.bootcamp.interviewflow.security.UserPrincipal;
 import com.bootcamp.interviewflow.service.ApplicationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/applications")
 @RequiredArgsConstructor
 @Tag(name = "Applications", description = "User job applications for employment")
 public class ApplicationController {
@@ -44,14 +46,16 @@ public class ApplicationController {
             @ApiResponse(responseCode = "401", description = "Unauthorized",
                     content = @Content(schema = @Schema(implementation = com.bootcamp.interviewflow.dto.ApiResponse.class))),
     })
-    @PostMapping("/applications")
-    public ResponseEntity<ApplicationResponse> create(@RequestBody @Valid CreateApplicationRequest dto) {
-        ApplicationResponse created = applicationService.create(dto);
+    @PostMapping
+    public ResponseEntity<ApplicationResponse> create(@RequestBody @Valid CreateApplicationRequest dto,
+                                                      @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        ApplicationResponse created = applicationService.create(dto, userPrincipal.getId());
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(created);
     }
 
+    //TODO: Should be moved to AdminApplicationController?
     @Operation(summary = "Get all job applications")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "List of applications",
@@ -59,7 +63,7 @@ public class ApplicationController {
             @ApiResponse(responseCode = "401", description = "Unauthorized",
                     content = @Content(schema = @Schema(implementation = com.bootcamp.interviewflow.dto.ApiResponse.class))),
     })
-    @GetMapping("/applications")
+    @GetMapping("/all")
     public ResponseEntity<List<ApplicationListDTO>> findAll() {
         List<ApplicationListDTO> all = applicationService.findAll();
         return ResponseEntity.ok(all);
@@ -74,9 +78,9 @@ public class ApplicationController {
             @ApiResponse(responseCode = "404", description = "User not found",
                     content = @Content(schema = @Schema(implementation = com.bootcamp.interviewflow.dto.ApiResponse.class)))
     })
-    @GetMapping(path = "/users/{userId}/applications")
-    public ResponseEntity<List<ApplicationListDTO>> getUserApplications(@PathVariable Long userId) {
-        return ResponseEntity.ok(applicationService.findAllByUserId(userId));
+    @GetMapping
+    public ResponseEntity<List<ApplicationListDTO>> getUserApplications(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ResponseEntity.ok(applicationService.findAllByUserId(userPrincipal.getId()));
     }
 
     @Operation(summary = "Delete a job application by ID")
@@ -88,9 +92,10 @@ public class ApplicationController {
             @ApiResponse(responseCode = "404", description = "User not found",
                     content = @Content(schema = @Schema(implementation = com.bootcamp.interviewflow.dto.ApiResponse.class)))
     })
-    @DeleteMapping("/applications/{id}")
-    public ResponseEntity<String> delete(@PathVariable Long id) {
-        applicationService.delete(id);
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Long id,
+                                         @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        applicationService.delete(id, userPrincipal.getId());
         return ResponseEntity.ok("Application with id " + id + " deleted");
     }
 
@@ -105,10 +110,11 @@ public class ApplicationController {
             @ApiResponse(responseCode = "404", description = "Application not found",
                     content = @Content(schema = @Schema(implementation = com.bootcamp.interviewflow.dto.ApiResponse.class)))
     })
-    @PatchMapping("/applications/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<ApplicationResponse> partialUpdate(
             @PathVariable Long id,
-            @RequestBody @Valid UpdateApplicationRequest dto) {
-        return ResponseEntity.ok(applicationService.partialUpdate(id, dto));
+            @RequestBody @Valid UpdateApplicationRequest dto,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ResponseEntity.ok(applicationService.partialUpdate(id, userPrincipal.getId(), dto));
     }
 }

--- a/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
@@ -3,7 +3,6 @@ package com.bootcamp.interviewflow.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -50,9 +49,4 @@ public class CreateApplicationRequest {
             }
     )
     private String status;
-
-    @NotNull(message = "User ID is required")
-    @Schema(description = "ID of the user applying for the job", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
-    private Long userId;
-
 }

--- a/src/main/java/com/bootcamp/interviewflow/repository/ApplicationRepository.java
+++ b/src/main/java/com/bootcamp/interviewflow/repository/ApplicationRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
     List<Application> findAllByUserId(Long userId);
+
+    Optional<Application> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/bootcamp/interviewflow/security/UserPrincipal.java
+++ b/src/main/java/com/bootcamp/interviewflow/security/UserPrincipal.java
@@ -1,0 +1,75 @@
+package com.bootcamp.interviewflow.security;
+
+import com.bootcamp.interviewflow.model.User;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Data
+public class UserPrincipal implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public UserPrincipal(Long id, String email, String password,
+                         Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("USER")
+        );
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/bootcamp/interviewflow/service/ApplicationService.java
+++ b/src/main/java/com/bootcamp/interviewflow/service/ApplicationService.java
@@ -4,7 +4,6 @@ import com.bootcamp.interviewflow.dto.ApplicationListDTO;
 import com.bootcamp.interviewflow.dto.ApplicationResponse;
 import com.bootcamp.interviewflow.dto.CreateApplicationRequest;
 import com.bootcamp.interviewflow.dto.UpdateApplicationRequest;
-import com.bootcamp.interviewflow.model.Application;
 
 import java.util.List;
 
@@ -12,11 +11,11 @@ public interface ApplicationService {
 
     List<ApplicationListDTO> findAllByUserId(Long userId);
 
-    ApplicationResponse create(CreateApplicationRequest dto);
+    ApplicationResponse create(CreateApplicationRequest dto, Long userId);
 
     List<ApplicationListDTO> findAll();
 
-    void delete(Long id);
+    void delete(Long id, Long userId);
 
-    ApplicationResponse partialUpdate(Long id, UpdateApplicationRequest dto);
+    ApplicationResponse partialUpdate(Long id, Long userId, UpdateApplicationRequest dto);
 }

--- a/src/main/java/com/bootcamp/interviewflow/service/CustomUserDetailsService.java
+++ b/src/main/java/com/bootcamp/interviewflow/service/CustomUserDetailsService.java
@@ -2,12 +2,11 @@ package com.bootcamp.interviewflow.service;
 
 import com.bootcamp.interviewflow.model.User;
 import com.bootcamp.interviewflow.repository.UserRepository;
+import com.bootcamp.interviewflow.security.UserPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -23,10 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getEmail())
-                .password(user.getPassword())
-                .authorities(Collections.emptyList()) // No specific roles
-                .build();
+        return UserPrincipal.create(user);
     }
 }


### PR DESCRIPTION
## Pull Request: Implement User Authorization for Application CRUD Operations

This PR implements authentication and authorization for all job application management endpoints to ensure users can only access and modify their own applications.

### Changes Made

**Security & Authentication:**
- Created `UserPrincipal` class for authentication context
- Updated security configuration to support authenticated user principal
- Moved all application endpoints to `/api/applications` secured path

**Controller Layer:**
- Removed `userId` parameters from all controller method signatures
- Implemented `@AuthenticationPrincipal UserPrincipal` for user context injection
- Updated paths

**Service Layer:**
- Added `userId` parameter to all service methods (`create`, `delete`, `partialUpdate`)
- Implemented user ownership validation using `findAndValidateOwnership` helper method
- Enhanced error handling to return 404 for unauthorized access attempts

**Repository Layer:**
- Added `findByIdAndUserId` method for secure user-scoped queries

**Testing:**
- Updated all unit tests to include user authentication scenarios
- Added test coverage for ownership validation and cross-user access prevention
- Fixed test mocks to use new repository methods and service signatures

**Data Transfer Objects:**
- Removed `userId` fields from DTOs where client should not supply user context

### Result
- Users can only view, create, update, and delete their own job applications
- Prevents unauthorized access to other users' application data
- Client no longer needs to provide `userId` in requests
