### PR TITLE
IF-69 add interview timestamp and notification fields to Application

### DIFF
--- a/src/main/java/com/bootcamp/interviewflow/dto/ApplicationListDTO.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/ApplicationListDTO.java
@@ -28,6 +28,13 @@ public record ApplicationListDTO(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
 
+        @Schema(description = "Timestamp when the interview is set for the application", example = "2025-07-18 14:30:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime interviewDate,
+
+        @Schema(description = "Enable reminder notifications for the interview?", example = "TRUE")
+        Boolean emailNotificationEnabled,
+
         @Schema(description = "Timestamp when the application was last updated", example = "2025-07-18 12:15:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime updatedAt

--- a/src/main/java/com/bootcamp/interviewflow/dto/ApplicationResponse.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/ApplicationResponse.java
@@ -38,6 +38,13 @@ public record ApplicationResponse(
 
         @Schema(description = "Timestamp when the application was last updated", example = "2025-07-18 15:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
 
-) {}
+        @Schema(description = "Timestamp when the interview is set for the application", example = "2025-07-18 14:30:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime interviewDate,
+
+        @Schema(description = "Enable reminder notifications for the interview?", example = "TRUE")
+        Boolean emailNotificationEnabled
+
+) { }

--- a/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/CreateApplicationRequest.java
@@ -31,9 +31,16 @@ public class CreateApplicationRequest {
     private String position;
 
     @Schema(description = "Timestamp when you actually applied for the job (optional - defaults to creation time)",
-            example = "2025-07-16T10:30:00")
+            example = "2025-07-16 10:30:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    LocalDateTime applyDate;
+    private LocalDateTime applyDate;
+
+    @Schema(description = "Timestamp when the interview is set for the application", example = "2025-07-16 10:30:00")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime interviewDate;
+
+    @Schema(description = "Enable reminder notifications for the interview?", example = "TRUE")
+    private Boolean emailNotificationsEnabled;
 
     @NotBlank(message = "Status is required")
     @Pattern(

--- a/src/main/java/com/bootcamp/interviewflow/dto/UpdateApplicationRequest.java
+++ b/src/main/java/com/bootcamp/interviewflow/dto/UpdateApplicationRequest.java
@@ -1,6 +1,7 @@
 package com.bootcamp.interviewflow.dto;
 
 import com.bootcamp.interviewflow.model.ApplicationStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -24,6 +25,11 @@ public class UpdateApplicationRequest {
 
     private ApplicationStatus status;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime applyDate;
-}
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime interviewDate;
+
+    private Boolean emailNotificationsEnabled;
+}

--- a/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationListMapper.java
+++ b/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationListMapper.java
@@ -18,6 +18,8 @@ public class ApplicationListMapper {
                 application.getPosition(),
                 application.getApplyDate(),
                 application.getCreatedAt(),
+                application.getInterviewDate(),
+                application.getEmailNotificationsEnabled(),
                 application.getUpdatedAt()
         );
     }

--- a/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationMapper.java
+++ b/src/main/java/com/bootcamp/interviewflow/mapper/ApplicationMapper.java
@@ -24,6 +24,14 @@ public class ApplicationMapper {
         if (dto.getApplyDate() != null) {
             app.setApplyDate(dto.getApplyDate());
         }
+        if (dto.getInterviewDate() != null) {
+            app.setInterviewDate(dto.getInterviewDate());
+        }
+        if (dto.getEmailNotificationsEnabled() != null) {
+            app.setEmailNotificationsEnabled(dto.getEmailNotificationsEnabled());
+        }
+
+
         return app;
     }
 
@@ -36,7 +44,9 @@ public class ApplicationMapper {
                 app.getPosition(),
                 app.getApplyDate(),
                 app.getCreatedAt(),
-                app.getUpdatedAt()
+                app.getUpdatedAt(),
+                app.getInterviewDate(),
+                app.getEmailNotificationsEnabled()
         );
     }
 }

--- a/src/main/java/com/bootcamp/interviewflow/model/Application.java
+++ b/src/main/java/com/bootcamp/interviewflow/model/Application.java
@@ -46,6 +46,12 @@ public class Application {
     @Column(name = "apply_date", nullable = false)
     private LocalDateTime applyDate;
 
+    @Column(name = "interview_date")
+    private LocalDateTime interviewDate;
+
+    @Column(name = "email_notifications_enabled", nullable = false)
+    private Boolean emailNotificationsEnabled;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -58,12 +64,14 @@ public class Application {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public Application(ApplicationStatus status, String companyName, String companyLink, String position, LocalDateTime applyDate, User user) {
+    public Application(ApplicationStatus status, String companyName, String companyLink, String position, LocalDateTime applyDate, LocalDateTime interviewDate, Boolean emailNotificationsEnabled, User user) {
         this.status = status;
         this.companyName = companyName;
         this.companyLink = companyLink;
         this.position = position;
         this.applyDate = applyDate;
+        this.interviewDate = interviewDate;
+        this.emailNotificationsEnabled = emailNotificationsEnabled;
         this.user = user;
     }
 }

--- a/src/main/java/com/bootcamp/interviewflow/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/bootcamp/interviewflow/service/ApplicationServiceImpl.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -40,7 +41,13 @@ public class ApplicationServiceImpl implements ApplicationService {
         app.setCompanyName(dto.getCompanyName());
         app.setCompanyLink(dto.getCompanyLink());
         app.setPosition(dto.getPosition());
-        app.setApplyDate(dto.getApplyDate());
+        app.setApplyDate(dto.getApplyDate() != null ? dto.getApplyDate() : LocalDateTime.now());
+
+        app.setInterviewDate(dto.getInterviewDate());
+
+        app.setEmailNotificationsEnabled(dto.getEmailNotificationsEnabled() != null ?
+                dto.getEmailNotificationsEnabled() : false);
+
         app.setStatus(ApplicationStatus.valueOf(dto.getStatus()));
         app.setUser(user);
 

--- a/src/main/resources/db/changelog/migrations/008-add-interview-fields.yml
+++ b/src/main/resources/db/changelog/migrations/008-add-interview-fields.yml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - logicalFilePath: migrations/004-add-interview-fields.yml
+  - changeSet:
+      id: 008-add-interview-fields
+      author: karolig
+      changes:
+        - addColumn:
+            tableName: applications
+            columns:
+              - column:
+                  name: interview_date
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: true
+              - column:
+                  name: email_notifications_enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: applications
+            columnName: interview_date
+        - dropColumn:
+            tableName: applications
+            columnName: email_notifications_enabled

--- a/src/test/java/com/bootcamp/interviewflow/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/controller/ApplicationControllerTest.java
@@ -37,7 +37,7 @@ class ApplicationControllerTest {
         Long userId = 42L;
         LocalDateTime now = LocalDateTime.of(2025, 7, 16, 12, 0);
         var dto = new ApplicationListDTO(
-                1L, ApplicationStatus.APPLIED, "Acme", "https://acme", "Eng",now, now, now
+                1L, ApplicationStatus.APPLIED, "Acme", "https://acme", "Eng",now, now, now, true, now
         );
         when(service.findAllByUserId(userId)).thenReturn(List.of(dto));
 

--- a/src/test/java/com/bootcamp/interviewflow/service/ApplicationServiceImplTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/service/ApplicationServiceImplTest.java
@@ -84,8 +84,8 @@ class ApplicationServiceImplTest {
         applications = List.of(app1, app2);
 
         dtos = List.of(
-                new ApplicationListDTO(1L, APPLIED, "Acme Corp", "https://acme.example", "Software Engineer", now,now, now),
-                new ApplicationListDTO(2L, REJECTED, "Globex", "https://globex.example", "Business Analyst", now,now, now)
+                new ApplicationListDTO(1L, APPLIED, "Acme Corp", "https://acme.example", "Software Engineer", now, now, now, true, now),
+                new ApplicationListDTO(2L, REJECTED, "Globex", "https://globex.example", "Business Analyst", now, now, now, true, now)
         );
     }
 
@@ -142,7 +142,9 @@ class ApplicationServiceImplTest {
                 testApp.getPosition(),
                 testApp.getApplyDate(),
                 testApp.getCreatedAt(),
-                testApp.getUpdatedAt());
+                testApp.getUpdatedAt(),
+                testApp.getInterviewDate(),
+                testApp.getEmailNotificationsEnabled());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(applicationRepository.save(testApp)).thenReturn(testApp);
@@ -232,7 +234,9 @@ class ApplicationServiceImplTest {
                 "Old Position",
                 null,
                 null,
-                null
+                null,
+                null,
+                true
         );
 
         when(applicationRepository.findById(appId)).thenReturn(Optional.of(existing));
@@ -283,7 +287,9 @@ class ApplicationServiceImplTest {
                 "NewPosition",
                 null,
                 null,
-                null
+                null,
+                null,
+                true
         );
 
         when(applicationRepository.findById(appId)).thenReturn(Optional.of(existing));
@@ -346,7 +352,9 @@ class ApplicationServiceImplTest {
                 "OldPosition",
                 null,
                 null,
-                null
+                null,
+                null,
+                true
         );
 
         when(applicationRepository.findById(appId)).thenReturn(Optional.of(existing));

--- a/src/test/java/com/bootcamp/interviewflow/service/NotesServiceTest.java
+++ b/src/test/java/com/bootcamp/interviewflow/service/NotesServiceTest.java
@@ -55,6 +55,8 @@ class NotesServiceTest {
                 "TestPosition",
                 now,
                 now,
+                true,
+                now,
                 now,
                 new User());
 
@@ -103,6 +105,8 @@ class NotesServiceTest {
                 "TestPosition",
                 now,
                 now,
+                true,
+                now,
                 now,
                 new User());
         Note note = new Note(100L, "Test note", application, now, now);
@@ -145,6 +149,8 @@ class NotesServiceTest {
                 "Link",
                 "TestPosition",
                 now,
+                now,
+                true,
                 now,
                 now,
                 new User());


### PR DESCRIPTION
## Description
Added interview scheduling and notification features to the application system. Users can now specify interview dates and enable email notifications when creating or updating job applications.

## Changes Made
- **Database**: Added `interview_date` (nullable) and `email_notifications_enabled` (default false) columns to applications table
- **Model**: Extended Application entity with new fields and updated constructor
- **DTOs**: Added interview date and notification fields to all request/response DTOs with proper JSON formatting
- **Service**: Updated create logic to handle default values for new fields
- **Mapper**: Enhanced mappers to include new fields in conversions
- **Tests**: Updated all test cases to accommodate new Application structure
- **API**: Maintained backward compatibility - new fields are optional in requests